### PR TITLE
6 refactor datamanager remove data state

### DIFF
--- a/src/dataManager.ts
+++ b/src/dataManager.ts
@@ -5,69 +5,98 @@ import { DEV_BUILD } from './config';
 import { getCurrentDate, createMockData } from './utils'
 import { TFile } from 'obsidian';
 import { METRIC_TYPES } from './constants';
+import { isActivityHeatmapData } from './utils';
 
 /**
  * Manages activity heatmap data for the plugin.
  */
 export class ActivityHeatmapDataManager {
     private metricManager: MetricManager;
-    private data: ActivityHeatmapData;
-
 
     /**
-     * Creates an instance of ActivityHeatmapDataManager.
+     * Creates an instance of ActivityHeatmapDataManager, which is responsible for reads/writes of activity heatmap data to disk.
      * @param plugin - The main plugin instance.
-     * @param loadedData - The parsed activity heatmap data from the data.json file.
      */
-    constructor(private plugin: ActivityHeatmapPlugin, loadedData: ActivityHeatmapData) {
+    constructor(private plugin: ActivityHeatmapPlugin) {
         this.metricManager = new MetricManager(plugin);
-        this.data = loadedData;
     }
 
     /**
      * Updates metrics for a single file and saves the data.
-     * This method is more efficient than updating all files as it only processes
-     * the changes for a single file.
-     * 
      * @param file - The Obsidian TFile to update metrics for
      */
     async updateMetricsForFile(file: TFile) {
         const today = getCurrentDate();
+        const data = await this.parseActivityData();
 
         for (const metricType of METRIC_TYPES) {
             const { checkpoint, activity } = await this.metricManager.calculateMetricsForFile(
                 metricType,
                 file,
-                this.data,
+                data,
                 today
             );
             
-            // Update only the specific file's checkpoint
-            this.data.checkpoints[metricType] = {
-                ...this.data.checkpoints[metricType],
+            data.checkpoints[metricType] = {
+                ...data.checkpoints[metricType],
                 [file.path]: checkpoint[file.path]
             };
-            this.data.activityOverTime[metricType] = activity;
+            data.activityOverTime[metricType] = activity;
         }
 
-        await this.plugin.saveData(this.data);
+        await this.plugin.saveData(data);
     }
 
     /**
      * Removes metrics for a deleted file from all metric types.
-     * This cleanup ensures we don't maintain data for files that no longer exist.
-     * 
      * @param filePath - The path of the file that was deleted
      */
     async removeFileMetrics(filePath: string) {
+        const data = await this.parseActivityData();
         for (const metricType of METRIC_TYPES) {
-            if (this.data.checkpoints[metricType]) {
-                delete this.data.checkpoints[metricType][filePath];
+            if (data.checkpoints[metricType]) {
+                delete data.checkpoints[metricType][filePath];
             }
         }
 
-        await this.plugin.saveData(this.data);
+        await this.plugin.saveData(data);
     }
+
+    /**
+	 * Parses the data read from disk (plugin's data.json file) into a usable format.
+     * If the data is not in the expected format, it returns an empty data structure to prevent errors.
+	 * @returns The parsed activity data.
+	 */
+	async parseActivityData(): Promise<ActivityHeatmapData> {
+		const loadedData = await this.plugin.loadData();
+
+		const emptyFrame: ActivityHeatmapData = {
+			checkpoints: METRIC_TYPES.reduce((acc, metric) => ({
+				...acc,
+				[metric]: {} as Record<string, number>
+			}), {} as Record<MetricType, Record<string, number>>),
+			activityOverTime: METRIC_TYPES.reduce((acc, metric) => ({
+				...acc,
+				[metric]: {} as Record<string, number>
+			}), {} as Record<MetricType, Record<string, number>>)
+		};
+
+		// Case of new user (no data.json)
+		if (!loadedData) {
+			return emptyFrame;
+		}
+
+		// Case of invalid or malformed activity heatmap data
+		if (!isActivityHeatmapData(loadedData)) {
+			return emptyFrame;
+		}
+
+		// Correct case: extract only the ActivityHeatmapData properties
+		return {
+			checkpoints: loadedData.checkpoints,
+			activityOverTime: loadedData.activityOverTime
+		};
+	}
 
     /**
      * Retrieves activity heatmap data for a specific metric type.
@@ -79,7 +108,8 @@ export class ActivityHeatmapDataManager {
             console.log("Using mock data");
             return createMockData();
         }
-        return this.data.activityOverTime[metricType];
+        const data = await this.parseActivityData();
+        return data.activityOverTime[metricType];
     }
 
 }

--- a/src/dataManager.ts
+++ b/src/dataManager.ts
@@ -27,7 +27,6 @@ export class ActivityHeatmapDataManager {
      * @param file - The Obsidian TFile to update metrics for
      */
     async updateMetricsForFile(file: TFile) {
-        // Queue this update to run after previous updates complete
         this.saveQueue = this.saveQueue.then(async () => {
             const today = getCurrentDate();
             const data = await this.parseActivityData();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,11 @@
 import { Plugin } from 'obsidian';
-import type { ActivityHeatmapData, ActivityHeatmapSettings, MetricType } from './types'
+import type { ActivityHeatmapSettings } from './types'
 import { ActivityHeatmapDataManager } from './dataManager'
-import { DEFAULT_SETTINGS, METRIC_TYPES } from './constants'
+import { DEFAULT_SETTINGS } from './constants'
 import { ActivityHeatmapSettingTab } from './settings'
 import { HeatmapModal } from './components/heatmapModal';
 import { DEV_BUILD } from './config';
 import { TFile } from 'obsidian';
-import { isActivityHeatmapData } from './utils';
 
 export default class ActivityHeatmapPlugin extends Plugin {
 	settings: ActivityHeatmapSettings;
@@ -18,7 +17,7 @@ export default class ActivityHeatmapPlugin extends Plugin {
 		await this.loadSettings();
 		this.addSettingTab(new ActivityHeatmapSettingTab(this.app, this));
 
-		this.dataManager = new ActivityHeatmapDataManager(this, await this.parseActivityData());
+		this.dataManager = new ActivityHeatmapDataManager(this);
 
 		this.registerEvent(
 			this.app.vault.on('modify', (file) => {
@@ -81,42 +80,6 @@ export default class ActivityHeatmapPlugin extends Plugin {
 		};
 		await this.saveData(dataToSave);
 	}
-
-	/**
-	 * Parses the activity data from the plugin's data.json file.
-	 * @returns The parsed activity data.
-	 */
-	async parseActivityData(): Promise<ActivityHeatmapData> {
-		const loadedData = await this.loadData();
-
-		const emptyFrame: ActivityHeatmapData = {
-			checkpoints: METRIC_TYPES.reduce((acc, metric) => ({
-				...acc,
-				[metric]: {} as Record<string, number>
-			}), {} as Record<MetricType, Record<string, number>>),
-			activityOverTime: METRIC_TYPES.reduce((acc, metric) => ({
-				...acc,
-				[metric]: {} as Record<string, number>
-			}), {} as Record<MetricType, Record<string, number>>)
-		};
-
-		// Case of new user (no data.json)
-		if (!loadedData) {
-			return emptyFrame;
-		}
-
-		// Case of invalid or malformed activity heatmap data
-		if (!isActivityHeatmapData(loadedData)) {
-			return emptyFrame;
-		}
-
-		// Correct case: extract only the ActivityHeatmapData properties
-		return {
-			checkpoints: loadedData.checkpoints,
-			activityOverTime: loadedData.activityOverTime
-		};
-	}
-
 }
 
 

--- a/src/metricManager.ts
+++ b/src/metricManager.ts
@@ -12,7 +12,7 @@ export class MetricManager {
     private metricCalculators: Record<MetricType, MetricCalculator>;
 
     /**
-     * Creates an instance of MetricManager.
+     * Creates an instance of MetricManager, which is responsible for calculating metrics for files.
      * @param plugin - The main plugin instance.
      */
     constructor(private plugin: ActivityHeatmapPlugin) {


### PR DESCRIPTION
Removed data state variable from dataManager, now it is a stateless intermediary between data.json disk storage and the rest of the plugin. Also, added promise queuing on updating metrics to handle burst of events, particularly at app startup.