### PR TITLE
5 properly capture file activity while plugin is inactive

### DIFF
--- a/src/dataManager.ts
+++ b/src/dataManager.ts
@@ -25,8 +25,9 @@ export class ActivityHeatmapDataManager {
     /**
      * Updates metrics for a single file and saves the data.
      * @param file - The Obsidian TFile to update metrics for
+     * @param isFirstTimeUpdate - Whether this is a first-time update (i.e. no existing data.json file)
      */
-    async updateMetricsForFile(file: TFile) {
+    async updateMetricsForFile(file: TFile, isFirstTimeUpdate: boolean) {
         this.saveQueue = this.saveQueue.then(async () => {
             const data = await this.parseActivityData();
             
@@ -35,6 +36,7 @@ export class ActivityHeatmapDataManager {
                     metricType,
                     file,
                     data,
+                    isFirstTimeUpdate
                 );
                                 
                 data.checkpoints[metricType] = {

--- a/src/dataManager.ts
+++ b/src/dataManager.ts
@@ -1,6 +1,6 @@
 import type ActivityHeatmapPlugin from './main'
 import { MetricManager } from './metricManager';
-import { ActivityData, MetricType, ActivityHeatmapData } from './types';
+import { ActivityData, MetricType, ActivityHeatmapData, CheckpointData } from './types';
 import { DEV_BUILD } from './config';
 import { getCurrentDate, createMockData } from './utils'
 import { TFile } from 'obsidian';
@@ -28,7 +28,6 @@ export class ActivityHeatmapDataManager {
      */
     async updateMetricsForFile(file: TFile) {
         this.saveQueue = this.saveQueue.then(async () => {
-            const today = getCurrentDate();
             const data = await this.parseActivityData();
             
             for (const metricType of METRIC_TYPES) {
@@ -36,9 +35,8 @@ export class ActivityHeatmapDataManager {
                     metricType,
                     file,
                     data,
-                    today
                 );
-                
+                                
                 data.checkpoints[metricType] = {
                     ...data.checkpoints[metricType],
                     [file.path]: checkpoint[file.path]
@@ -49,7 +47,6 @@ export class ActivityHeatmapDataManager {
             await this.plugin.saveData(data);
         });
         
-        // Wait for this update to complete
         await this.saveQueue;
     }
 
@@ -93,8 +90,8 @@ export class ActivityHeatmapDataManager {
 		const emptyFrame: ActivityHeatmapData = {
 			checkpoints: METRIC_TYPES.reduce((acc, metric) => ({
 				...acc,
-				[metric]: {} as Record<string, number>
-			}), {} as Record<MetricType, Record<string, number>>),
+				[metric]: {} as CheckpointData
+			}), {} as Record<MetricType, CheckpointData>),
 			activityOverTime: METRIC_TYPES.reduce((acc, metric) => ({
 				...acc,
 				[metric]: {} as Record<string, number>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,18 +19,13 @@ export default class ActivityHeatmapPlugin extends Plugin {
 
 		this.dataManager = new ActivityHeatmapDataManager(this);
 
+		this.app.workspace.onLayoutReady(async () => {
+			await this.scanVault();
+		});
+
 		this.registerEvent(
 			this.app.vault.on('modify', (file) => {
 				if (file instanceof TFile && file.extension === 'md') {
-					this.dataManager.updateMetricsForFile(file);
-				}
-			})
-		);
-
-		this.registerEvent(
-			this.app.vault.on('create', (file) => {
-				if (file instanceof TFile && file.extension === 'md') {
-					console.log("Creating file", file.path);
 					this.dataManager.updateMetricsForFile(file);
 				}
 			})
@@ -79,6 +74,16 @@ export default class ActivityHeatmapPlugin extends Plugin {
 			...this.settings
 		};
 		await this.saveData(dataToSave);
+	}
+
+	/**
+	 * Upon plugin init, does an initial scan of the vault to update the metrics for all existing files
+	 */
+	async scanVault() {
+		const markdownFiles = this.app.vault.getMarkdownFiles();
+		for (const file of markdownFiles) {
+			await this.dataManager.updateMetricsForFile(file);
+		}
 	}
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ export default class ActivityHeatmapPlugin extends Plugin {
 		this.registerEvent(
 			this.app.vault.on('modify', (file) => {
 				if (file instanceof TFile && file.extension === 'md') {
-					this.dataManager.updateMetricsForFile(file);
+					this.dataManager.updateMetricsForFile(file, false);
 				}
 			})
 		);
@@ -81,8 +81,10 @@ export default class ActivityHeatmapPlugin extends Plugin {
 	 */
 	async scanVault() {
 		const markdownFiles = this.app.vault.getMarkdownFiles();
+		const data = await this.loadData();
+		const isFirstTimeUpdate = !data;
 		for (const file of markdownFiles) {
-			await this.dataManager.updateMetricsForFile(file);
+			await this.dataManager.updateMetricsForFile(file, isFirstTimeUpdate);
 		}
 	}
 }

--- a/src/metricManager.ts
+++ b/src/metricManager.ts
@@ -1,7 +1,7 @@
 import type { ActivityHeatmapData, CheckpointData, ActivityData, MetricType } from './types'
 import type ActivityHeatmapPlugin from './main'
 import type { TFile } from 'obsidian';
-import { calculateAbsoluteDifference} from './utils';
+import { calculateAbsoluteDifference, getDateStringFromTimestamp } from './utils';
 
 type MetricCalculator = (file: TFile) => number | Promise<number>;
 
@@ -66,25 +66,26 @@ export class MetricManager {
         metricName: MetricType,
         file: TFile,
         latestData: ActivityHeatmapData,
-        dateToday: string
     ): Promise<{ checkpoint: CheckpointData; activity: ActivityData }> {
         const calculator = this.metricCalculators[metricName];
         if (!calculator) {
             throw new Error(`No calculator found for metric: ${metricName}`);
         }
 
-
         const checkpoint: CheckpointData = {};
         const activity: ActivityData = { ...latestData.activityOverTime[metricName] };
         
         try {
             const metricValue = await calculator(file);
-            checkpoint[file.path] = metricValue;
+            checkpoint[file.path] = {
+                value: metricValue,
+                mtime: file.stat.mtime
+            };
 
             if (latestData.checkpoints[metricName] && file.path in latestData.checkpoints[metricName]) {
-                const previousValue = latestData.checkpoints[metricName][file.path];
-                const absoluteDifference = calculateAbsoluteDifference(metricValue, previousValue);
-                activity[dateToday] = (activity[dateToday] || 0) + absoluteDifference;
+                const previousRecord = latestData.checkpoints[metricName][file.path];
+                const absoluteDifference = calculateAbsoluteDifference(metricValue, previousRecord.value);
+                activity[getDateStringFromTimestamp(file.stat.mtime)] = (activity[getDateStringFromTimestamp(file.stat.mtime)] || 0) + absoluteDifference;
             }
         } catch (error) {
             console.error(`Error calculating ${metricName} for file ${file.path}:`, error);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,10 @@ export type FilePath = string;
 export type DateString = string; // Format: YYYY-MM-DD
 export type MetricType = typeof METRIC_TYPES[number];
 
-export type CheckpointData = Record<FilePath, number>;
+export type CheckpointData = Record<FilePath, {
+    value: number;
+    mtime: number;
+}>;
 
 export type ActivityData = Record<DateString, number>;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,13 +3,19 @@ import { METRIC_TYPES } from './constants';
 
 
 /**
- * Type guard for CheckpointData (Record<FilePath, number>)
+ * Type guard for CheckpointData (Record<FilePath, { value: number, mtime: number }>)
  */
 export function isCheckpointData(data: any): data is CheckpointData {
     if (typeof data !== 'object' || data === null) return false;
     
-    return Object.entries(data).every(([path, value]) => 
-        typeof path === 'string' && typeof value === 'number'
+    return Object.entries(data).every(([path, record]) => 
+        typeof path === 'string' && 
+        typeof record === 'object' &&
+        record !== null &&
+        'value' in record &&
+        'mtime' in record &&
+        typeof (record as any).value === 'number' &&
+        typeof (record as any).mtime === 'number'
     );
 }
 
@@ -147,4 +153,13 @@ export function calculateAbsoluteDifference(current: number, previous: number | 
         return current;
     }
     return Math.abs(current - previous);
+}
+
+/**
+ * Converts a timestamp to a date string.
+ * @param timestamp - The timestamp to convert.
+ * @returns The date string.
+ */
+export function getDateStringFromTimestamp(timestamp: number): string {
+    return new Date(timestamp).toISOString().split('T')[0];
 }


### PR DESCRIPTION
changes:
- Remove 'create file' event trigger for metric update (overlaps w/ modify event + vault scan)
- Run update on all vault files upon plugin initialization
- Add file last-modified-timestamp to checkpoint data to more accurately attribute activity to the proper date
- Add check for first-time users to avoid attributing initial checkpoints as activity
- Modify updating metrics logic to handle edge case where file is created offline